### PR TITLE
chore: update version to 0.1.1 for Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openmcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "rmcp",


### PR DESCRIPTION
I didn't notice that the Cargo.lock is also updated...