### PR TITLE
feat(cargo): static link openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ name = "openmcp"
 version = "0.1.1"
 dependencies = [
  "clap",
+ "openssl",
  "rmcp",
  "rmcp-proxy",
  "tokio",
@@ -1037,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1054,7 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tokio-util = { version = "0.7.15" }
 clap = { version = "4.5.37", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
This PR static links the openssl library:

```
> cargo build --release
    Finished `release` profile [optimized] target(s) in 0.08s

> ldd target/release/openmcp
        linux-vdso.so.1 (0x00007ffceebc8000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fc9721ce000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fc971119000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc970e00000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fc972207000)
```